### PR TITLE
Couple fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gwasm-api"
-version = "0.1.0-alpha.1"
+version = "0.1.0"
 authors = ["Golem RnD Team <contact@golem.network>"]
 edition = "2018"
 license = "GPL-3.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,42 +8,59 @@ use tokio::timer;
 #[derive(Debug, Fail)]
 pub enum Error {
     /// Wraps actix's `MailboxError` error
-    #[fail(display = "Actix mailbox error")]
+    #[fail(display = "internal gWasm API error: {}", _0)]
     MailboxError(MailboxError),
 
     /// Wraps tokio's `timer::Error` error
-    #[fail(display = "Tokio timer error")]
+    #[fail(display = "internal gWasm API error: {}", _0)]
     TimerError(timer::Error),
 
     /// Wraps libstd's `std::io::Error` error
-    #[fail(display = "I/O error")]
+    #[fail(display = "internal gWasm API error: {}", _0)]
     IOError(io::Error),
 
     /// Wraps Golem's `actix_wamp::Error` error
-    #[fail(display = "Actix WAMP error")]
+    #[fail(display = "internal Golem error: {}", _0)]
     WampError(actix_wamp::Error),
 
     /// Wraps Golem RPC's `golem_rpc_api::Error` error
-    #[fail(display = "Golem RPC error")]
+    #[fail(display = "internal Golem error: {}", _0)]
     GolemRPCError(golem_rpc_api::Error),
 
     /// Wraps `tokio_ctrlc_error::KeyboardInterrupt` which is used to handle
     /// Ctrl-C interrupt event for the lib's client
-    #[fail(display = "Keyboard interrupt")]
+    #[fail(display = "received Ctrl-C interrupt")]
     KeyboardInterrupt(tokio_ctrlc_error::KeyboardInterrupt),
 
     /// Wraps other `tokio_ctrlc_error::IoError` type errors
-    #[fail(display = "Tokio Ctrl-C error")]
+    #[fail(display = "internal gWasm API error: {}", _0)]
     CtrlcError(tokio_ctrlc_error::IoError),
 
     /// Wraps `chrono::ParseError` error
-    #[fail(display = "Chrono error")]
+    #[fail(display = "error parsing Timeout value: {}", _0)]
     ChronoError(chrono::ParseError),
 
     /// Error generated when trying to create a zero [`Timeout`](../timeout/struct.Timeout.html)
     /// value for a Golem Task
-    #[fail(display = "Zero timeout error")]
+    #[fail(display = "zero timeout \"00:00:00\" is forbidden")]
     ZeroTimeoutError,
+
+    /// Error when no TaskInfo is received when polling for task progress
+    /// in [`poll_task_progress`](../golem/fn.poll_task_progress.html)
+    #[fail(display = "empty TaskInfo received from Golem")]
+    EmptyTaskInfo,
+
+    /// Error when no progress can be extracted from TaskInfo
+    #[fail(display = "empty progress in TaskInfo")]
+    EmptyProgress,
+
+    /// Error when gWasm task was aborted externally
+    #[fail(display = "task aborted externally")]
+    TaskAborted,
+
+    /// Error when gWasm task timed out
+    #[fail(display = "task timed out")]
+    TaskTimedOut,
 }
 
 impl From<io::Error> for Error {

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,14 +1,14 @@
 //! Convenience types for creating and managing gWasm tasks
-use super::error::Error;
-use super::timeout::Timeout;
-use super::Result;
+use super::{error::Error, timeout::Timeout, Result};
 use serde::Serialize;
-use std::collections::BTreeMap;
-use std::convert::TryFrom;
-use std::fs::{self, File};
-use std::io::BufReader;
-use std::path::{Path, PathBuf};
-use std::str::FromStr;
+use std::{
+    collections::BTreeMap,
+    convert::TryFrom,
+    fs::{self, File},
+    io::BufReader,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
 
 /// Wrapper type for easy passing of gWasm binary
 #[derive(Debug)]

--- a/src/timeout.rs
+++ b/src/timeout.rs
@@ -1,6 +1,5 @@
 //! Types representing Golem Task's timeout values
-use super::error::Error;
-use super::Result;
+use super::{error::Error, Result};
 use chrono::naive::NaiveTime;
 use serde::{Serialize, Serializer};
 use std::str::FromStr;


### PR DESCRIPTION
* handle erroneous task completion: `Abort` and `Timeout` are now handled as
  errors
* clean up displaying errors
* refactor imports