### PR TITLE
Add output_path field to Task::Options struct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gwasm-api"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Golem RnD Team <contact@golem.network>"]
 edition = "2018"
 license = "GPL-3.0"


### PR DESCRIPTION
This commit adds `output_path` field to `Task::Options` struct. This
is needed to partially address request golemfactory/g-flite#28. The
field is made non-optional as after this change lands in upstream,
it will be **required** by the Wasm app on the Golem side.

cc @zakaprov FYI that this is a potentially breaking change for Brass
backend in `gwasm-runner`.