### PR TITLE
Handle budget in Task def

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
 
 jobs:
   build_stable_nix:
@@ -32,10 +30,6 @@ jobs:
       with:
         command: fmt
         args: --all -- --check
-    - name: Build debug
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
     - name: Build release
       uses: actions-rs/cargo@v1
       with:
@@ -45,6 +39,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: test
+        args: --release
 
   build_stable_win:
     name: Build stable Windows
@@ -70,12 +65,6 @@ jobs:
         vcpkg search openssl
         vcpkg install openssl:x64-windows
         vcpkg list
-    - name: Build debug
-      env:
-        VCPKGRS_DYNAMIC: ${{ 1 }}
-      run: |
-        vcpkg integrate install
-        cargo build
     - name: Build release
       env:
         VCPKGRS_DYNAMIC: ${{ 1 }}
@@ -87,7 +76,7 @@ jobs:
         VCPKGRS_DYNAMIC: ${{ 1 }}
       run: |
         vcpkg integrate install
-        cargo test
+        cargo test --release
 
   build_nightly:
     name: Build beta & nightly

--- a/src/task.rs
+++ b/src/task.rs
@@ -51,6 +51,7 @@ pub struct TaskBuilder<'a> {
     binary: GWasmBinary<'a>,
     name: Option<String>,
     bid: Option<f64>,
+    budget: Option<f64>,
     timeout: Option<Timeout>,
     subtask_timeout: Option<Timeout>,
     input_dir_path: PathBuf,
@@ -66,6 +67,7 @@ impl<'a> TaskBuilder<'a> {
             binary,
             name: None,
             bid: None,
+            budget: None,
             timeout: None,
             subtask_timeout: None,
             input_dir_path: workspace.as_ref().join("in"),
@@ -84,6 +86,12 @@ impl<'a> TaskBuilder<'a> {
     /// Sets task's bid value
     pub fn bid(mut self, bid: f64) -> Self {
         self.bid = Some(bid);
+        self
+    }
+
+    /// Sets task's budget value
+    pub fn budget(mut self, budget: f64) -> Self {
+        self.budget = Some(budget);
         self
     }
 
@@ -185,7 +193,14 @@ impl<'a> TaskBuilder<'a> {
             options.subtasks.insert(name, subtask);
         }
 
-        Ok(Task::new(name, bid, timeout, subtask_timeout, options))
+        Ok(Task::new(
+            name,
+            bid,
+            self.budget,
+            timeout,
+            subtask_timeout,
+            options,
+        ))
     }
 }
 
@@ -219,6 +234,8 @@ pub struct Task {
     task_type: String,
     name: String,
     bid: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    budget: Option<f64>,
     timeout: Timeout,
     subtask_timeout: Timeout,
     options: Options,
@@ -229,6 +246,7 @@ impl Task {
     pub fn new<S: Into<String>>(
         name: S,
         bid: f64,
+        budget: Option<f64>,
         timeout: Timeout,
         subtask_timeout: Timeout,
         options: Options,
@@ -237,6 +255,7 @@ impl Task {
             task_type: "wasm".into(),
             name: name.into(),
             bid,
+            budget,
             timeout,
             subtask_timeout,
             options,
@@ -251,6 +270,11 @@ impl Task {
     /// Task's bid value
     pub fn bid(&self) -> f64 {
         self.bid
+    }
+
+    /// Task's budget value
+    pub fn budget(&self) -> Option<f64> {
+        self.budget
     }
 
     /// Task's [`Timeout`](../timeout/struct.Timeout.html) value


### PR DESCRIPTION
This PR adds optional `budget` field to the `Task` def. If the field is `None`, then it is skipped from serializing as the default value is handled on the Golem side.