### PR TITLE
Add structure for the Guide book

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,8 +101,12 @@ jobs:
       with:
         command: build
         
-  docs:
-    name: Docs
+  # Build mdBook guide and publish to gh-pages
+  # Steps inspired by @alexcrichton's [cargo-wasi]
+  # conf: kudos Alex!
+  # [cargo-wasi]: https://github.com/bytecodealliance/cargo-wasi/blob/master/.github/workflows/main.yml
+  book:
+    name: Book docs
     runs-on: macOS-latest
     
     steps:
@@ -114,8 +118,16 @@ jobs:
         profile: minimal
         toolchain: stable
         override: true
-    - name: Build docs
-      uses: actions-rs/cargo@v1
-      with:
-        command: doc
-        args: --no-deps
+    - name: Install mdbook
+      run: |
+        set -e
+        curl -L https://github.com/rust-lang/mdBook/releases/download/v0.3.5/mdbook-v0.3.5-x86_64-apple-darwin.tar.gz | tar xzf -
+        echo ::add-path::`pwd`
+    - run: cd doc && mdbook build
+    - name: Push to gh-pages
+      run: curl -LsSf https://git.io/fhJ8n | rustc - && (cd doc/book && ../../rust_out)
+      env:
+        GITHUB_DEPLOY_KEY: ${{ secrets.GITHUB_DEPLOY_KEY }}
+        BUILD_REPOSITORY_ID: ${{ github.repository }}
+        BUILD_SOURCEVERSION: ${{ github.sha }}
+      if: github.event_name == 'push' && github.event.ref == 'refs/heads/master'

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@
     <a href="https://crates.io/crates/gwasm-api"><img src="https://img.shields.io/crates/d/gwasm-api.svg?style=flat-square" alt="Download" /></a>
     <a href="https://docs.rs/gwasm-api/"><img src="https://img.shields.io/badge/docs-latest-blue.svg?style=flat-square" alt="docs.rs docs" /></a>
   </p>
+
+  <h3>
+    <a href="https://golemfactory.github.io/gwasm-rust-api/">Guide</a> 
+  </h3>
 </div>
 
 [gWasm](https://docs.golem.network/#/Products/Brass-Beta/gWASM) is Golem's new

--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -1,0 +1,4 @@
+# Summary
+
+- [Introduction](./index.md)
+- [API documentation](./api_docs.md)

--- a/doc/api_docs.md
+++ b/doc/api_docs.md
@@ -1,0 +1,3 @@
+# API documentation
+
+You can find API documentation by following [this link to docs.rs](https://docs.rs/gwasm-api).

--- a/doc/book.toml
+++ b/doc/book.toml
@@ -1,0 +1,5 @@
+[book]
+authors = ["Golem RnD Team <contact@golem.network>"]
+multilingual = false
+src = "."
+title = "gWasm API for Rust apps"

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,0 +1,15 @@
+# Introduction
+
+`gwasm-api` is a Rust library for interfacing your native apps with [gWasm]. `gWasm` is
+Golem's new meta use-case which allows Golem's developers/users to deploy their Wasm
+apps on Golem Network.
+
+`gwasm-api` provides convenience structures and functions for creating a `gWasm` task
+and connecting with Golem Network all from native Rust code.
+
+In this guide, you will find step-by-step instructions that will get you started with
+the API. We will achieve this by building a version of the [g-flite] app albeit without
+all the niceties and features such as animated progressbar, etc.
+
+[gWasm]: https://docs.golem.network/#/Products/Brass-Beta/gWASM 
+[g-flite]: https://github.com/golemfactory/g-flite


### PR DESCRIPTION
This commit laids out structure and automation for publishing
a Guide book with example step-by-step usage of `gwasm-api`.